### PR TITLE
本番環境でCSSを作動させるための変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
本番環境でCSSが作動しなかったため、config/environment/production.rbの記述を一部変更しました。
これで作動しなかった場合は、Nginxに問題がある場合があるようなので、それを調査します。

#11  参照。