### PR TITLE
本番環境でのdocker-composeの修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6.5
 
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs vim
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
 
 RUN mkdir /mahjong_parlor
 ENV APP_ROOT /mahjong_parlor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ volumes:
   public_data:
   tmp_data:
   log_data:
-  bundle_data:
 
 services:
   db:
@@ -21,6 +20,7 @@ services:
   app:
     build:
       context: .
+      dockerfile: Dockerfile
     environment:
       MYSQL_USERNAME: root
       MYSQL_PASSWORD: password
@@ -35,7 +35,6 @@ services:
       - public_data:/mahjong_parlor/public
       - tmp_data:/mahjong_parlor/tmp
       - log_data:/mahjong_parlor/log
-      - bundle_data:/usr/local/bundle
     depends_on:
       - db
 


### PR DESCRIPTION
docker-compose.ymlからbundlerに関するvolumeを削除しました。
加えて、本番環境では不要と思われるvimのインストールに関する記述も削除しました。

#16  参照。