### PR TITLE
各種一覧ページの修正

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -554,7 +554,8 @@ footer {
 }
 
 // 8. Images
-.review-image {
+.parlor-image {
+  height: 160px;
   text-align: center;
   margin: 5px auto;
 }

--- a/app/controllers/parlors_controller.rb
+++ b/app/controllers/parlors_controller.rb
@@ -4,11 +4,13 @@ class ParlorsController < ApplicationController
 
   def index
     @parlors = Parlor.all
-    @page_parlors = @parlors.includes(:reviews, :favorites).page(params[:page]).per(10)
+    @page_parlors = @parlors.includes(:favorites, :favored_users,
+                                      reviews: { images_attachments: :blob }).
+      page(params[:page]).per(10)
   end
 
   def show
-    @parlor = Parlor.find(params[:id])
+    @parlor = Parlor.includes(reviews: { images_attachments: :blob }).find(params[:id])
     @reviews = @parlor.reviews.new_order.with_attached_images.
       includes(:user, :like_users, comments: :user).page(params[:page]).per(9)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,7 +23,8 @@ class UsersController < ApplicationController
 
   def favorites
     @user = User.find(params[:id])
-    @parlors = @user.favorite_parlors.includes(:reviews, :favorites)
+    @parlors = @user.favorite_parlors.includes(:favorites, :favored_users,
+                                               reviews: { images_attachments: :blob })
   end
 
   def likes

--- a/app/models/parlor.rb
+++ b/app/models/parlor.rb
@@ -52,8 +52,12 @@ class Parlor < ApplicationRecord
     end
   end
 
+  def favored_user?(user)
+    favored_users.include?(user)
+  end
+
   def display_images(count: nil)
-    images = reviews.with_attached_images.map { |review| review.images }.flatten
+    images = reviews.map { |review| review.images }.flatten
     if count
       images.take(count)
     else

--- a/app/views/favorites/create.js.erb
+++ b/app/views/favorites/create.js.erb
@@ -1,3 +1,7 @@
 $('#favorite_form_<%= @parlor.id %>').html(
     "<%= escape_javascript(render 'parlors/remove_from_favorite', parlor: @parlor) %>"
 )
+
+$('#favorites_count_<%= @parlor.id %>').html(
+    "<h5>行きつけ登録： <strong><%= @parlor.favorites.size %>ユーザー</strong></h5>"
+)

--- a/app/views/favorites/destroy.js.erb
+++ b/app/views/favorites/destroy.js.erb
@@ -1,3 +1,7 @@
 $('#favorite_form_<%= @parlor.id %>').html(
     "<%= escape_javascript(render 'parlors/add_to_favorite', parlor: @parlor) %>"
 )
+
+$('#favorites_count_<%= @parlor.id %>').html(
+    "<h5>行きつけ登録： <strong><%= @parlor.favorites.size %>ユーザー</strong></h5>"
+)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -29,6 +29,7 @@
               <ul class="dropdown-menu">
                 <li><%= link_to "プロフィール", user_path(current_user) %></li>
                 <li><%= link_to "いいね！", likes_user_path(current_user) %></li>
+                <li><%= link_to "フォロワー", followers_user_path(current_user) %></li>
                 <li><%= link_to "アカウント情報変更", edit_user_registration_path %></li>
                 <li><%= link_to "ログアウト", destroy_user_session_path, method: :delete %></li>
               </ul>

--- a/app/views/parlors/_detail.html.erb
+++ b/app/views/parlors/_detail.html.erb
@@ -21,7 +21,9 @@
         <h5><%= parlor.smoking_i18n %></h5>
       </div>
       <small><a href="#" data-toggle="modal" data-target="#edit-parlor">情報を編集する</a></small>
-      <br>
+      <div class="parlor-attribute" id="favorites_count_<%= parlor.id %>">
+        <h5>行きつけ登録： <strong><%= parlor.favorites.size %>ユーザー</strong></h5>
+      </div>
       <%= link_to "レビューを投稿する！", new_parlor_review_path(parlor), class: "form-btn btn-info" %>
       <%= render 'favorite_form', parlor: parlor %>
       <% if user_signed_in? %>

--- a/app/views/parlors/_favorite_form.html.erb
+++ b/app/views/parlors/_favorite_form.html.erb
@@ -1,6 +1,6 @@
 <% if user_signed_in? %>
   <div id="favorite_form_<%= parlor.id %>">
-    <% if current_user.favorite?(parlor) %>
+    <% if parlor.favored_user?(current_user) %>
       <%= render 'parlors/remove_from_favorite', parlor: parlor %>
     <% else %>
       <%= render 'parlors/add_to_favorite', parlor: parlor %>

--- a/app/views/parlors/_images.html.erb
+++ b/app/views/parlors/_images.html.erb
@@ -1,13 +1,13 @@
 <div class="parlor-images">
   <div class="row">
     <% if parlor.display_images.empty? %>
-      <div class="review-image">
+      <div class="parlor-image">
         <p>写真は投稿されていません</p>
       </div>
     <% else %>
-      <% parlor.display_images(count: 8).each do |image| %>
-        <div class="col-sm-3 col-xs-6">
-          <div class="review-image">
+      <% parlor.display_images(count: yield(:images_count).to_i).each do |image| %>
+        <div class="<%= yield(:images_class) %>">
+          <div class="parlor-image">
             <%= link_to(rails_blob_path(image), target: '_blank', rel: 'noopener noreferrer') do %>
               <%= image_tag image.variant(resize: '250x160'), class: 'img-rounded' %>
             <% end %>

--- a/app/views/parlors/_parlor.html.erb
+++ b/app/views/parlors/_parlor.html.erb
@@ -4,11 +4,14 @@
     <span><small><%= parlor.address %></small></span>
     <h4>総合評価： <strong><%= parlor.rating %></strong></h4>
     <h5>レビュー件数： <strong><%= parlor.reviews.size %>件</strong></h5>
-    <h5>行きつけ登録： <strong><%= parlor.favorites.size %>ユーザー</strong></h5>
-  </div>
-  <div class="row">
-    <div class="col-sm-8 col-sm-offset-2 col-xs-12">
-      <%= render 'parlors/favorite_form', parlor: parlor %>
+    <div id="favorites_count_<%= parlor.id %>">
+      <h5>行きつけ登録： <strong><%= parlor.favorites.size %>ユーザー</strong></h5>
+    </div>
+    <%= render 'parlors/images', parlor: parlor %>
+    <div class="row">
+      <div class="col-sm-8 col-sm-offset-2 col-xs-12">
+        <%= render 'parlors/favorite_form', parlor: parlor %>
+      </div>
     </div>
   </div>
   <hr>

--- a/app/views/parlors/index.html.erb
+++ b/app/views/parlors/index.html.erb
@@ -1,3 +1,5 @@
+<% provide :images_count, "2" %>
+<% provide :images_class, "col-sm-6 col-xs-12" %>
 <div id="parlors-index-map"></div>
 <div class="container">
   <h5>地図のマーカーをクリックするとお店の情報を確認できます</h5>

--- a/app/views/parlors/show.html.erb
+++ b/app/views/parlors/show.html.erb
@@ -1,4 +1,6 @@
 <% provide :title, @parlor.name %>
+<% provide :images_count, "8" %>
+<% provide :images_class, "col-sm-3 col-xs-6" %>
 <div class="container">
   <%= render 'detail', parlor: @parlor %>
   <hr>

--- a/app/views/relationships/create.js.erb
+++ b/app/views/relationships/create.js.erb
@@ -1,3 +1,7 @@
-$('#follow_form').html("<%= escape_javascript(render 'users/unfollow', user: @user) %>")
+$('#follow_form_<%= @user.id %>').html(
+    "<%= escape_javascript(render 'users/unfollow', user: @user) %>"
+)
 
 $('#followers_count').html("<p>フォロワー: <strong><%= @user.followers.count %></strong></p>")
+
+$('#follower_count_<%= @user.id %>').text("フォロワー: <%= @user.followers.size %>")

--- a/app/views/relationships/destroy.js.erb
+++ b/app/views/relationships/destroy.js.erb
@@ -1,3 +1,7 @@
-$('#follow_form').html("<%= escape_javascript(render 'users/follow', user: @user) %>")
+$('#follow_form_<%= @user.id %>').html(
+    "<%= escape_javascript(render 'users/follow', user: @user) %>"
+)
 
 $('#followers_count').html("<p>フォロワー: <strong><%= @user.followers.count %></strong></p>")
+
+$('#follower_count_<%= @user.id %>').text("フォロワー: <%= @user.followers.size %>")

--- a/app/views/reviews/_modal.html.erb
+++ b/app/views/reviews/_modal.html.erb
@@ -22,7 +22,7 @@
           <div class="row">
             <% review.images.each do |image| %>
               <div class="col-sm-6 col-xs-12">
-                <div class="review-image">
+                <div class="parlor-image">
                   <%= link_to(rails_blob_path(image), target: '_blank', rel: 'noopener noreferrer') do %>
                     <%= image_tag image.variant(resize: '250x160'), class: 'img-rounded' %>
                   <% end %>

--- a/app/views/users/_follow_form.html.erb
+++ b/app/views/users/_follow_form.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-sm-8 col-sm-offset-2 col-xs-12">
-    <div id="follow_form">
+    <div class="follow_form" id="follow_form_<%= user.id %>">
       <% if user_signed_in? && user != current_user %>
         <% if current_user.following?(user) %>
           <%= render 'users/unfollow', user: user %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -4,7 +4,7 @@
     <p>
       <span>レビュー: <%= user.reviews_count %>件</span>
       <span>&emsp;</span>
-      <span>フォロワー: <%= user.followers.size %></span>
+      <span id="follower_count_<%= user.id %>">フォロワー: <%= user.followers.size %></span>
     </p>
     <p><%= user.content %></p>
   </div>

--- a/app/views/users/favorites.html.erb
+++ b/app/views/users/favorites.html.erb
@@ -1,4 +1,6 @@
 <%= provide :title, "#{@user.username}さんの行きつけ" %>
+<% provide :images_count, "2" %>
+<% provide :images_class, "col-sm-6 col-xs-12" %>
 <div class="container">
   <div class="index">
     <h2><strong><%= link_to @user.username, @user %>さんの行きつけ</strong></h2>

--- a/spec/models/parlor_spec.rb
+++ b/spec/models/parlor_spec.rb
@@ -126,6 +126,24 @@ RSpec.describe Parlor, type: :model do
     end
   end
 
+  describe "#display_images" do
+    let(:parlor) { create(:parlor) }
+    let!(:reviews_with_images) { create_list(:review, 3, :images_attached, parlor: parlor) }
+    let!(:reviews_without_images) { create_list(:review, 3, parlor: parlor) }
+
+    context "without count parameter" do
+      it "returns array including 3 images" do
+        expect(parlor.display_images.length).to eq 3
+      end
+    end
+
+    context "with count parameter 2" do
+      it "returns array including 2 images" do
+        expect(parlor.display_images(count: 2).length).to eq 2
+      end
+    end
+  end
+
   describe "#format_address" do
     context "with Japan" do
       let(:parlor) { create(:parlor, address: "日本、〒150-0043 東京都渋谷区道玄坂２丁目１０−１２") }

--- a/spec/system/parlors_spec.rb
+++ b/spec/system/parlors_spec.rb
@@ -58,6 +58,43 @@ RSpec.describe "Parlors", type: :system do
     end
   end
 
+  describe "Index" do
+    let(:user) { create(:user) }
+    let!(:parlors) { create_list(:parlor, 3) }
+    let(:parlor_with_images) { create(:parlor) }
+    let!(:review) { create(:review, :images_attached, parlor: parlor_with_images) }
+
+    it "has an index page working well", js: true do
+      visit root_path
+
+      expect(page).to have_selector '.parlor-index', count: 4
+      expect(page).to have_selector 'img', count: 1
+      expect(page).not_to have_link "行きつけに登録"
+      expect(page).not_to have_link "行きつけ解除"
+
+      sign_in user
+      visit root_path
+
+      expect(page).to have_selector '.parlor-index', count: 4
+      expect(page).to have_selector 'img', count: 1
+      expect(page).to have_link "行きつけに登録", count: 4
+      expect(page).not_to have_link "行きつけ解除"
+
+      within all('.parlor-index')[0] do
+        expect(page).to have_text "行きつけ登録： 0ユーザー"
+
+        click_on "行きつけに登録"
+
+        expect(page).to have_text "行きつけ登録： 1ユーザー"
+      end
+
+      expect(page).to have_selector '.parlor-index', count: 4
+      expect(page).to have_selector 'img', count: 1
+      expect(page).to have_link "行きつけに登録", count: 3
+      expect(page).to have_link "行きつけ解除", count: 1
+    end
+  end
+
   describe "Edit a parlor" do
     let(:parlor) { create(:parlor, website: "", smoking: 'no_smoking') }
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -445,7 +445,7 @@ RSpec.describe "Users", type: :system do
           expect(page).to have_text "フォロー: 3"
           expect(page).not_to have_link "アカウント情報編集"
 
-          within('#follow_form') do
+          within('.follow_form') do
             expect(page).not_to have_link "フォロー"
           end
         end
@@ -470,7 +470,7 @@ RSpec.describe "Users", type: :system do
           expect(page).to have_text "フォロー: 5"
           expect(page).not_to have_link "アカウント情報編集"
 
-          within('#follow_form') do
+          within('.follow_form') do
             expect(page).not_to have_link "フォロー"
           end
         end
@@ -493,7 +493,7 @@ RSpec.describe "Users", type: :system do
           expect(page).to have_text "フォロー: 3"
           expect(page).to have_link "アカウント情報編集", href: edit_user_registration_path
 
-          within('#follow_form') do
+          within('.follow_form') do
             expect(page).not_to have_link "フォロー"
           end
 
@@ -524,11 +524,11 @@ RSpec.describe "Users", type: :system do
           expect(page).to have_text "フォロー: 5"
           expect(page).not_to have_link "アカウント情報編集"
 
-          within('#follow_form') do
+          within('.follow_form') do
             expect(page).to have_link "フォロー"
           end
 
-          within('#follow_form') do
+          within('.follow_form') do
             click_on "フォロー"
             expect(page).to have_link "フォロー解除"
           end
@@ -545,7 +545,7 @@ RSpec.describe "Users", type: :system do
         visit user_path(other_user)
 
         within('.user-detail') do
-          within('#follow_form') do
+          within('.follow_form') do
             click_on "フォロー解除"
             expect(page).to have_link "フォロー"
           end
@@ -557,6 +557,78 @@ RSpec.describe "Users", type: :system do
 
         within('.user-detail') do
           expect(page).to have_text "フォロー: 3"
+        end
+      end
+    end
+
+    describe "Following and Followers Page" do
+      let!(:active_relationships) { create_list(:relationship, 4, follower: user) }
+      let!(:passive_relationships) { create_list(:relationship, 3, followed: user) }
+
+      it "has following and followers page working well", js: true do
+        visit followers_user_path(user)
+
+        expect(title).to eq "ユーザーさんのフォロワー | Mahjong Parlor"
+
+        within('.index') do
+          expect(page).to have_selector '.user-index', count: 3
+          expect(page).not_to have_link "フォロー"
+        end
+
+        visit following_user_path(user)
+
+        expect(title).to eq "ユーザーさんのフォロー | Mahjong Parlor"
+
+        within('.index') do
+          expect(page).to have_selector '.user-index', count: 4
+          expect(page).not_to have_link "フォロー解除"
+        end
+
+        sign_in user
+
+        visit followers_user_path(user)
+
+        expect(title).to eq "ユーザーさんのフォロワー | Mahjong Parlor"
+
+        within('.index') do
+          expect(page).to have_selector '.user-index', count: 3
+          expect(page).to have_link "フォロー", count: 3
+        end
+
+        within all('.user-index')[0] do
+          expect(page).to have_text "フォロワー: 0"
+        end
+
+        within all('.follow_form')[0] do
+          click_on "フォロー"
+          expect(page).to have_link "フォロー解除"
+        end
+
+        within all('.user-index')[0] do
+          expect(page).to have_text "フォロワー: 1"
+        end
+
+        visit following_user_path(user)
+
+        expect(title).to eq "ユーザーさんのフォロー | Mahjong Parlor"
+
+        within('.index') do
+          expect(page).to have_selector '.user-index', count: 5
+          expect(page).to have_link "フォロー解除", count: 5
+        end
+
+        within all('.user-index')[0] do
+          expect(page).to have_text "フォロワー: 1"
+        end
+
+        within all('.follow_form')[0] do
+          click_on "フォロー解除"
+          expect(page).to have_link "フォロー"
+          expect(page).not_to have_link "フォロー解除"
+        end
+
+        within all('.user-index')[0] do
+          expect(page).to have_text "フォロワー: 0"
         end
       end
     end


### PR DESCRIPTION
下記の点について、修正を行いました。
```
- 雀荘の一覧ページに店舗の写真を表示
- "行きつけ", "フォロー"ボタンを押すと、各登録数が非同期で変化
```
close #52 